### PR TITLE
fix: :ambulance: fix some CSS class names that conflicted with system classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,62 @@
-0.3.0
+# CHANGELOG
+
+## 0.3.1
+
+- Fix some CSS class names that conflicted with system classes
+
+## 0.3.0
+
 - v13
 
-0.2.0
+## 0.2.0
+
 - v12
 - small fix
 
-0.1.8
+## 0.1.8
+
 - v11
 
-0.1.7
+## 0.1.7
+
 - roulete animation improvement
 - more options for auto select
 - fix selectRandomToken
 - dialog for custom auto select
 
-0.1.6
+## 0.1.6
+
 - fix pan error, PepijnMC
 - chat wait for roulete
 - you can disable chat
 
-0.1.5
+## 0.1.5
+
 - selectRandomToken api
 - randomToken([]) api
 - docs - readme
 - roulete and panToToken fixes
 - roulete animation options
 
-0.1.4
+## 0.1.4
+
 - roulete improvement
 - target token
 - pan to token
 - ping to token
 - sound volume is client now
 
-0.1.3
+## 0.1.3
+
 - small fixes
 - token art or actor sheet art settings
 - sequencer roulete
 
-0.1.2
+## 0.1.2
+
 - token layer button gm only now
 - immersive mode
 
-0.1.0
-manifest fix
+## 0.1.0
+
+-manifest fix

--- a/css/wheel-of-destiny.css
+++ b/css/wheel-of-destiny.css
@@ -1,4 +1,4 @@
-.titulo {
+.wod-titulo {
   background-color: black;
   height: 26px;
   color: beige;
@@ -8,7 +8,7 @@
   padding-top: 5px;
 }
 
-.boxcheck {
+.wod-boxcheck {
   text-align: center;
   justify-content: center;
   margin-left: 5px;
@@ -16,29 +16,29 @@
   padding: 10px;
 }
 
-.boxcheckpai {
+.wod-boxcheckpai {
   background-color: rgba(107, 107, 107, 0.166);
   height: auto;
   margin-bottom: 10px;
 }
 
-.containerform {
+.wod-containerform {
   display: flex;
 }
 
-.containerduo {
+.wod-containerduo {
   height: 50%;
   display: inline-block;
 }
 
-.container {
+.wod-container {
   position: relative;
   text-align: center;
   color: white;
 }
 
 /* Centered text */
-.messageOnTop {
+.wod-messageOnTop {
   position: absolute;
   top: 0%;
   left: 50%;
@@ -49,7 +49,7 @@
 }
 
 /* Centered text */
-.messageOnBottom {
+.wod-messageOnBottom {
   position: absolute;
   top: 100%;
   left: 50%;

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "flags": {}
     }
   ],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/templates/dialog.html
+++ b/templates/dialog.html
@@ -1,7 +1,7 @@
 <body>
-  <div class="container">
-    <div class="messageOnTop">{{topMessage}}</div>
+  <div class="wod-container">
+    <div class="wod-messageOnTop">{{topMessage}}</div>
     <img src="{{imagePath}}" alt="{{tokenName}}" style="width:100%;">
-    <div class="messageOnBottom">{{tokenName}}</div>
+    <div class="wod-messageOnBottom">{{tokenName}}</div>
   </div>
 </body>

--- a/templates/dialog_autoselect.html
+++ b/templates/dialog_autoselect.html
@@ -1,6 +1,6 @@
 <div class="divTableRow">
-<p class="titulo">Custom Auto Select</p>
-<div class="boxcheckpai">
+<p class="wod-titulo">Custom Auto Select</p>
+<div class="wod-boxcheckpai">
    <form>
       <div class="form-group">
          <label style="text-align:left;">Custom Auto Select:</label>


### PR DESCRIPTION
FIX: #9 
Change some generic css class names adding a `wod` prefix. This will avoid class names conflicting with game systems and other modules class names. 